### PR TITLE
some instances on debian / ubuntu of services just do not seem to have a status capability

### DIFF
--- a/steps/900-services
+++ b/steps/900-services
@@ -80,7 +80,7 @@ while (my($service, $s) = each(%services)) {
     untie %dir;
   } else {
     if (i_distro("debian", "ubuntu")) {
-      $running = lc(qx/service $service status/);
+      $running = lc(qx/invoke-rc.d $service status/);
       if ($running =~ m/$service.*is running/i || $running =~ m/start\/running/i) {
         $running = 1;
       } elsif ($running =~ "$service is not running") {


### PR DESCRIPTION
I haven't actually checked debian status abilities for the service command, but I am happy to make that assumption that it's the same.  Also, changed it to use the service command due to the fact that snmpd for instance has a built-in snmptrapd service associated with the snmpd service, so while you have snmpd enabled, but have snmptrapd disabled, it returns with a 2, and that doesn't work so well.  I'm also parsing as you can see the return message from the service command on debian, ubuntu.
