### PR TITLE
adding package iptables-persistent for saving iptables rules

### DIFF
--- a/steps/950-iptables
+++ b/steps/950-iptables
@@ -94,7 +94,7 @@ return unless (@accept || @drop || @append);
 
 # Make sure iptables is installed
 if (i_distro("debian", "ubuntu")) {
-  package_check("iptables");
+  package_check("iptables", "iptables-persistent");
   file_modify("/etc/default/iptables", undef,
               [ 's/enable_autosave=true/enable_autosave=false/',
                 's/enable_save_counters=true/enable_save_counters=false/' ])


### PR DESCRIPTION
Referenced packages:
https://packages.debian.org/search?keywords=iptables-persistent
http://packages.ubuntu.com/precise/iptables-persistent

These packages by default save the iptables, and iptables6 on shutdown.  They also apply the firewall rules upon certain runlevels.  This is done by default at package install time.
